### PR TITLE
Change the port type to int32_t

### DIFF
--- a/rfaas/include/rfaas/resources.hpp
+++ b/rfaas/include/rfaas/resources.hpp
@@ -15,12 +15,12 @@ namespace rfaas {
 
   struct server_data
   {
-    int16_t port;
+    int32_t port;
     int16_t cores;
     char address[16];
 
     server_data();
-    server_data(const std::string & ip, int16_t port, int16_t cores);
+    server_data(const std::string & ip, int32_t port, int16_t cores);
 
     template <class Archive>
     void save(Archive & ar) const

--- a/rfaas/lib/resources.cpp
+++ b/rfaas/lib/resources.cpp
@@ -14,7 +14,7 @@ namespace rfaas {
     cores(-1)
   {}
 
-  server_data::server_data(const std::string & ip, int16_t port, int16_t cores):
+  server_data::server_data(const std::string & ip, int32_t port, int16_t cores):
     port(port),
     cores(cores)
   {


### PR DESCRIPTION
The port type was set to `int16_t` (supported ports from −32768 to 32767) which made half of the ports unusable and did not notify the user about it. To cover the whole range of ports from 0 to 65635 we have two options:
1. Use `uint16_t` seen usually in the context of the port number.
2. Use `int32_t`.

I selected the second option because we use -1 for an invalid value and space is not at a premium.