### PR TITLE
Fix a compilation error: invalid conversion from ‘const char*’ to ‘char*’

### DIFF
--- a/rdmalib/lib/rdmalib.cpp
+++ b/rdmalib/lib/rdmalib.cpp
@@ -34,7 +34,7 @@ namespace rdmalib {
     if(passive)
       hints.ai_flags = RAI_PASSIVE;
 
-    impl::expect_zero(rdma_getaddrinfo(ip.c_str(), std::to_string(port).c_str(), &hints, &addrinfo));
+    impl::expect_zero(rdma_getaddrinfo(const_cast<char *>(ip.c_str()), const_cast<char *>(std::to_string(port).c_str()), &hints, &addrinfo));
     this->_port = port;
   }
 


### PR DESCRIPTION
## Introduction
This commit cast the ip address and port number to `char *` in the call to `rdma_getaddrinfo` function. This is to avoid  `invalid conversion` error and to ensure that the correct arguments are passed to it.

## Error Message:
Here is my environment information:

- Compiler: GNU g++ 12.2.0
- Linux Distribution: Ubuntu 20.04.3 LTS

When I followed the readme instructions for the compilation, I encounter following error.

```
william@art1:~/rFaaS$ cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release

william@art1:~/rFaaS$ cmake --build .
Scanning dependencies of target spdlog
[  1%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/spdlog.cpp.o
[  3%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/stdout_sinks.cpp.o
[  5%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/color_sinks.cpp.o
[  7%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/file_sinks.cpp.o
[  9%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/async.cpp.o
[ 10%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/cfg.cpp.o
[ 12%] Building CXX object _deps/spdlog-build/CMakeFiles/spdlog.dir/src/fmt.cpp.o
[ 14%] Linking CXX static library libspdlog.a
[ 14%] Built target spdlog
Scanning dependencies of target rdmalib
[ 16%] Building CXX object CMakeFiles/rdmalib.dir/rdmalib/lib/buffer.cpp.o
[ 18%] Building CXX object CMakeFiles/rdmalib.dir/rdmalib/lib/connection.cpp.o
[ 20%] Building CXX object CMakeFiles/rdmalib.dir/rdmalib/lib/functions.cpp.o
[ 21%] Building CXX object CMakeFiles/rdmalib.dir/rdmalib/lib/rdmalib.cpp.o
/home/William/rFaaS/rdmalib/lib/rdmalib.cpp: In constructor ‘rdmalib::Address::Address(const string&, int, bool)’:
/home/William/rFaaS/rdmalib/lib/rdmalib.cpp:37:48: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
   37 |     impl::expect_zero(rdma_getaddrinfo(ip.c_str(), std::to_string(port).c_str(), &hints, &addrinfo));
      |                                        ~~~~~~~~^~
      |                                                |
      |                                                const char*
In file included from /home/William/rFaaS/rdmalib/include/rdmalib/connection.hpp:12,
                 from /home/William/rFaaS/rdmalib/lib/rdmalib.cpp:2:
/usr/include/rdma/rdma_cma.h:706:28: note:   initializing argument 1 of ‘int rdma_getaddrinfo(char*, char*, rdma_addrinfo*, rdma_addrinfo**)’
  706 | int rdma_getaddrinfo(char *node, char *service,
      |                      ~~~~~~^~~~
/home/William/rFaaS/rdmalib/lib/rdmalib.cpp:37:78: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
   37 |     impl::expect_zero(rdma_getaddrinfo(ip.c_str(), std::to_string(port).c_str(), &hints, &addrinfo));
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                                              |
      |                                                                              const char*
In file included from /home/William/rFaaS/rdmalib/include/rdmalib/connection.hpp:12,
                 from /home/William/rFaaS/rdmalib/lib/rdmalib.cpp:2:
/usr/include/rdma/rdma_cma.h:706:40: note:   initializing argument 2 of ‘int rdma_getaddrinfo(char*, char*, rdma_addrinfo*, rdma_addrinfo**)’
  706 | int rdma_getaddrinfo(char *node, char *service,
      |                                  ~~~~~~^~~~~~~
make[2]: *** [CMakeFiles/rdmalib.dir/build.make:102: CMakeFiles/rdmalib.dir/rdmalib/lib/rdmalib.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:176: CMakeFiles/rdmalib.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```