### PR TITLE
Allow for multiple spdlog versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.19)
 include(FetchContent)
 project(serverless-rdma)
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -17,7 +17,7 @@ endif()
 ###
 # spdlog
 ###
-find_package(spdlog 1.8.0 EXACT QUIET)
+find_package(spdlog 1.8...<1.10)
 if(NOT spdlog_FOUND)
   message(STATUS "Downloading and building spdlog dependency")
   FetchContent_Declare(spdlog
@@ -27,6 +27,7 @@ if(NOT spdlog_FOUND)
   )
   FetchContent_MakeAvailable(spdlog)
 else()
+  message(STATUS "Using installed spdlog version")
   add_custom_target(spdlog)
 endif()
 


### PR DESCRIPTION
We need to support a scenario where the user has `spdlog` already installed. The main use case is having to build `spdlog` without bundled `fmt`, since another project can provide the `fmt` which would lead to conflicts. The current limit on `1.8.0` is too strict, and it provides no feedback to the user.

Now we support a range, with all versions `1.8x` and `1.9x` of `spdlog`. We exclude `1.10` as it is not compatible with rFaaS at the moment. The user should be able to provide a path to `spdlog` installation:

```
cmake -Dspdlog_ROOT=../spdlog-1.9.2/install/lib/cmake
```

If the version is not compatible, we should now let CMake print the warning:

```
CMake Warning at cmake/dependencies.cmake:20 (find_package):                                                                                                                                                                                                  
  Could not find a configuration file for package "spdlog" that is compatible
  with requested version range "1.8...<1.10".
                                                               
  The following configuration files were considered but not accepted:
                                                               
    /work/serverless/2021/rfaas/new_repo/spdlog-1.10.0/install/lib/cmake/spdlog/spdlogConfig.cmake, version: 1.10.0
```