### PR TITLE
Added help message for PkgConfig library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,20 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)
 
 ###
+# PkgConfig 
+###
+
+find_package(PkgConfig REQUIRED)
+if (NOT PkgConfig_FOUND)
+    message(FATAL_ERROR "PkgConfig library not found")
+endif (NOT PkgConfig_FOUND)
+
+###
 # librdmacm
 ###
-find_package(PkgConfig REQUIRED)
+
 pkg_check_modules(rdmacm REQUIRED IMPORTED_TARGET librdmacm)
+
 ###
 # libibverbs
 ###


### PR DESCRIPTION
## Story
When installing rFaaS on the Ubuntu system, an error caused by missing `PkgConfig` may occur, but it may appear to be caused by `Pthread` at first glance. This could mislead newcomers.

Here is the error log:
```
Performing C SOURCE FILE Test CMAKE_HAVE_LIBC_PTHREAD failed with the following output:
Change Dir: /home/ubuntu/rFaaS/build-test/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/make cmTC_884b3/fast && /usr/bin/make -f CMakeFiles/cmTC_884b3.dir/build.make CMakeFiles/cmTC_884b3.dir/build
make[1]: Entering directory '/home/ubuntu/rFaaS/build-test/CMakeFiles/CMakeTmp'
Building C object CMakeFiles/cmTC_884b3.dir/src.c.o
/usr/bin/clang-15   -DCMAKE_HAVE_LIBC_PTHREAD   -o CMakeFiles/cmTC_884b3.dir/src.c.o   -c /home/ubuntu/rFaaS/build-test/CMakeFiles/CMakeTmp/src.c
Linking C executable cmTC_884b3
/usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_884b3.dir/link.txt --verbose=1
/usr/bin/clang-15  -DCMAKE_HAVE_LIBC_PTHREAD    CMakeFiles/cmTC_884b3.dir/src.c.o  -o cmTC_884b3
/usr/bin/ld: CMakeFiles/cmTC_884b3.dir/src.c.o: in function `main':
src.c:(.text+0x32): undefined reference to `pthread_create'
/usr/bin/ld: src.c:(.text+0x3b): undefined reference to `pthread_detach'
/usr/bin/ld: src.c:(.text+0x48): undefined reference to `pthread_join'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [CMakeFiles/cmTC_884b3.dir/build.make:87: cmTC_884b3] Error 1
make[1]: Leaving directory '/home/ubuntu/rFaaS/build-test/CMakeFiles/CMakeTmp'
make: *** [Makefile:121: cmTC_884b3/fast] Error 2

Source file was:
#include <pthread.h>

void* test_func(void* data)
{
  return data;
}

int main(void)
{
  pthread_t thread;
  pthread_create(&thread, NULL, test_func, NULL);
  pthread_detach(thread);
  pthread_join(thread, NULL);
  pthread_atfork(NULL, NULL, NULL);
  pthread_exit(NULL);

  return 0;
}
```

## Solution

Perhaps we could add some error messages to CMake to inform users of the actual cause of the error, as shown below.

```
ubuntu@rFaaS-1:~/rFaaS/build-test$ CC=clang-15 cmake -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_BUILD_TYPE=Release ..
-- The C compiler identification is Clang 15.0.7
-- The CXX compiler identification is Clang 15.0.7
-- Check for working C compiler: /usr/bin/clang-15
-- Check for working C compiler: /usr/bin/clang-15 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++-15
-- Check for working CXX compiler: /usr/bin/clang++-15 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:41 (find_package_handle_standard_args)
  CMakeLists.txt:90 (find_package)
```