### PR TITLE
Fixed 'no declaration matches' and other compiler errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+bin/
+configuration/
+volumes/
+containers/config/htpasswd

--- a/benchmarks/warm_benchmark.cpp
+++ b/benchmarks/warm_benchmark.cpp
@@ -33,9 +33,11 @@ int main(int argc, char ** argv)
   rfaas::devices::deserialize(in_dev);
   in_dev.close();
 
+  #ifdef USE_GNI_AUTH
   rdmalib::Configuration::get_instance().configure_cookie(
     rfaas::devices::instance()._configuration.authentication_credential
   );
+  #endif
 
   // Read benchmark settings
   std::ifstream benchmark_cfg{opts.json_config};

--- a/rdmalib/include/rdmalib/buffer.hpp
+++ b/rdmalib/include/rdmalib/buffer.hpp
@@ -61,10 +61,11 @@ namespace rdmalib {
       #endif
       #ifdef USE_LIBFABRIC
       void *lkey() const;
+      uint64_t rkey() const;
       #else
       uint32_t lkey() const;
+      uint32_t rkey() const;
       #endif
-      uint64_t rkey() const;
       ScatterGatherElement sge(uint32_t size, uint32_t offset) const;
     };
 
@@ -78,6 +79,12 @@ namespace rdmalib {
     RemoteBuffer();
     // When accessing the remote buffer, we might not need to know the size.
     RemoteBuffer(uintptr_t addr, uint64_t rkey, uint32_t size = 0);
+
+    #ifdef USE_LIBFABRIC
+    RemoteBuffer(uintptr_t addr, uint64_t rkey, uint32_t size);
+    #else
+    RemoteBuffer(uintptr_t addr, uint32_t rkey, uint32_t size);
+    #endif
 
     template<class Archive>
     void serialize(Archive & ar)

--- a/rdmalib/include/rdmalib/rdmalib.hpp
+++ b/rdmalib/include/rdmalib/rdmalib.hpp
@@ -25,6 +25,7 @@ extern "C" {
 
 #include <rdmalib/buffer.hpp>
 #include <rdmalib/connection.hpp>
+#include <mutex>
 
 namespace rdmalib {
 
@@ -45,7 +46,9 @@ namespace rdmalib {
     ~Configuration();
 
     std::once_flag _access_flag;
+    #ifdef USE_GNI_AUTH
     drc_info_handle_t _credential_info;
+    #endif
     uint64_t _cookie;
     uint32_t _credential;
     bool _is_configured;

--- a/rdmalib/lib/buffer.cpp
+++ b/rdmalib/lib/buffer.cpp
@@ -247,6 +247,12 @@ namespace rdmalib {
     size(0)
   {}
 
+  RemoteBuffer::RemoteBuffer(uintptr_t addr, uint64_t rkey, uint32_t size):
+    addr(addr),
+    rkey(rkey),
+    size(size)
+  {}
+
   #ifdef USE_LIBFABRIC
   RemoteBuffer::RemoteBuffer(uintptr_t addr, uint64_t rkey, uint32_t size):
     addr(addr),

--- a/rdmalib/lib/rdmalib.cpp
+++ b/rdmalib/lib/rdmalib.cpp
@@ -57,6 +57,8 @@ namespace rdmalib {
     return _instance;
   }
 
+  #ifdef USE_GNI_AUTH
+
   void Configuration::configure_cookie(uint32_t credential)
   {
     Configuration& inst = _get_instance();
@@ -87,6 +89,7 @@ namespace rdmalib {
   {
     return _is_configured;
   }
+  #endif
 
   Configuration Configuration::_instance;
 
@@ -136,7 +139,10 @@ namespace rdmalib {
     impl::expect_zero(rdma_getaddrinfo(ip.c_str(), std::to_string(port).c_str(), &hints, &addrinfo));
     #endif
     this->_port = port;
+
+    #ifdef USE_LIBFABRIC
     this->_ip = ip;
+    #endif
   }
 
   Address::Address(const std::string & sip,  const std::string & dip, int port)

--- a/server/executor/cli.cpp
+++ b/server/executor/cli.cpp
@@ -36,6 +36,8 @@ int main(int argc, char ** argv)
     opts.func_size, opts.msg_size, opts.recv_buffer_size, opts.max_inline_data,
     opts.timeout
   );
+
+  #ifdef USE_GNI_AUTH
   spdlog::info(
     "My manager runs at {}:{}, its secret is {}, the accounting buffer is at {} with rkey {}, cookie {}",
     opts.mgr_address, opts.mgr_port, opts.mgr_secret,
@@ -46,6 +48,13 @@ int main(int argc, char ** argv)
   rdmalib::Configuration::get_instance().configure_cookie(
     opts.authentication_cookie
   );
+  #else
+  spdlog::info(
+    "My manager runs at {}:{}, its secret is {}, the accounting buffer is at {} with rkey {}",
+    opts.mgr_address, opts.mgr_port, opts.mgr_secret,
+    opts.accounting_buffer_addr, opts.accounting_buffer_rkey
+  );
+  #endif
 
   executor::ManagerConnection mgr{
     opts.mgr_address,

--- a/server/executor_manager/cli.cpp
+++ b/server/executor_manager/cli.cpp
@@ -52,9 +52,11 @@ int main(int argc, char ** argv)
   std::ifstream in_dev{opts.device_database};
   rfaas::devices::deserialize(in_dev);
 
+  #ifdef USE_GNI_AUTH
   rdmalib::Configuration::get_instance().configure_cookie(
     rfaas::devices::instance()._configuration.authentication_credential
   );
+  #endif
 
   // Read executor manager settings
   std::ifstream in_cfg{opts.json_config};


### PR DESCRIPTION
Much of the code that was split into two implementations based on the `USE_LIBFABRIC` and `USE_CRAY_GNI` flags were causing errors that did not happen in the [libfabric](https://github.com/spcl/rfaas/tree/libfabric) branch. This PR fixes those errors and allows this branch to be compiled.