### PR TITLE
ReaderWriterQueue and Update README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,18 @@ include(FetchContent)
 project(serverless-rdma)
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+FetchContent_Declare(
+  readerwriterqueue
+  GIT_REPOSITORY    https://github.com/cameron314/readerwriterqueue
+  GIT_TAG           master
+)
+FetchContent_Declare(
+  pistache
+  GIT_REPOSITORY https://github.com/pistacheio/pistache
+  GIT_TAG        master # It's better to use a specific release tag
+)
+FetchContent_MakeAvailable(readerwriterqueue pistache)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ its `ugni` provider.
 - `libibverbs` with headers installed.
 - `librdmacm` with headers installed.
 - [pistache](https://github.com/pistacheio/pistache) - HTTP and REST framework.
+- [readerwriterqueue](https://github.com/cameron314/readerwriterqueue) - Lock-free queue or C++
 
 Furthermore, we fetch and build the following dependencies during CMake build - unless
 they are found already in the system.


### PR DESCRIPTION
#14 Add ReaderWriterQueue and Update README

- Integrated ReaderWriterQueue as a dependency via the CMake build system.
- Updated README to acknowledge the use of ReaderWriterQueue and Pistache.
- Note: Additional testing may be required to ensure proper integration.