### PR TITLE
lease max free memory

### DIFF
--- a/rfaas/include/rfaas/allocation.hpp
+++ b/rfaas/include/rfaas/allocation.hpp
@@ -25,6 +25,8 @@ namespace rfaas {
     int32_t port;
     char address[16];
     //LeasedNode nodes[MAX_NODES_PER_LEASE];
+    int16_t cores;
+    int32_t memory;
   };
 
   struct AllocationRequest {

--- a/rfaas/include/rfaas/allocation.hpp
+++ b/rfaas/include/rfaas/allocation.hpp
@@ -8,7 +8,7 @@ namespace rfaas {
 
   struct LeaseRequest {
     // > 0: Number of cores to be allocated
-    // < 0: client_id with negative sign, deallocation & disconnect request
+    // <= 0: client_id with negative sign, deallocation & disconnect request
     int16_t cores;
     int32_t memory;
   };

--- a/rfaas/include/rfaas/client.hpp
+++ b/rfaas/include/rfaas/client.hpp
@@ -54,12 +54,14 @@ namespace rfaas {
       }
 
       int response_id = responses[0].wr_id;
+      LeaseResponse& lease_response = _resource_mgr.response(response_id);
+
       return rfaas::executor{
-        std::string{_resource_mgr.response(response_id).address},
-        _resource_mgr.response(response_id).port,
-        cores,
-        memory,
-        _resource_mgr.response(response_id).lease_id,
+        std::string{lease_response.address},
+        lease_response.port,
+        lease_response.cores,
+        lease_response.memory,
+        lease_response.lease_id,
         dev
       };
     }

--- a/rfaas/include/rfaas/client.hpp
+++ b/rfaas/include/rfaas/client.hpp
@@ -54,7 +54,7 @@ namespace rfaas {
       }
 
       int response_id = responses[0].wr_id;
-      LeaseResponse& lease_response = _resource_mgr.response(response_id);
+      const LeaseResponse& lease_response = _resource_mgr.response(response_id);
 
       return rfaas::executor{
         std::string{lease_response.address},

--- a/server/resource_manager/db.cpp
+++ b/server/resource_manager/db.cpp
@@ -75,6 +75,11 @@ namespace rfaas { namespace resource_manager {
         continue;
       }
 
+      // Lease entire free memory when receiving reserved value -1
+      if (memory == -1) {
+        memory = shared_ptr->_free_memory;
+      }
+
       if(!shared_ptr->lease(numcores, memory)) {
         ++it;
         SPDLOG_DEBUG("Node {} cannot be used, not enough resources!", shared_ptr->node);
@@ -84,6 +89,8 @@ namespace rfaas { namespace resource_manager {
       lease.lease_id = _lease_count++;
       lease.port = shared_ptr->port;
       strncpy(lease.address, shared_ptr->address.c_str(), Executor::ADDRESS_LENGTH);
+      lease.cores = numcores;
+      lease.memory = memory;
 
       bool is_total = shared_ptr->is_fully_leased();
       if(is_total) {

--- a/server/resource_manager/executor.cpp
+++ b/server/resource_manager/executor.cpp
@@ -48,11 +48,18 @@ namespace rfaas::resource_manager {
 
   bool Executor::lease(int cores, int memory)
   {
+
+    // Lease entire free memory when receiving reserved value -1
+    if (memory == -1) {
+      memory = _free_memory;
+    }
+
     // Not enough memory? skip
     if(_free_memory < memory) {
       return false;
     }
 
+    // Note that values of cores <= 0 are reserved by the resource manager to disconnect clients
     if(_free_cores < cores) {
       return false;
     }

--- a/server/resource_manager/executor.cpp
+++ b/server/resource_manager/executor.cpp
@@ -48,7 +48,10 @@ namespace rfaas::resource_manager {
 
   bool Executor::lease(int cores, int memory)
   {
-    // Not enough memory? skip
+    if (cores <= 0 || memory <= 0 || _free_cores <= 0 || _free_memory <= 0) {
+      return false;
+    }
+
     if(_free_memory < memory) {
       return false;
     }

--- a/server/resource_manager/executor.cpp
+++ b/server/resource_manager/executor.cpp
@@ -48,18 +48,11 @@ namespace rfaas::resource_manager {
 
   bool Executor::lease(int cores, int memory)
   {
-
-    // Lease entire free memory when receiving reserved value -1
-    if (memory == -1) {
-      memory = _free_memory;
-    }
-
     // Not enough memory? skip
     if(_free_memory < memory) {
       return false;
     }
 
-    // Note that values of cores <= 0 are reserved by the resource manager to disconnect clients
     if(_free_cores < cores) {
       return false;
     }

--- a/server/resource_manager/manager.cpp
+++ b/server/resource_manager/manager.cpp
@@ -322,8 +322,8 @@ void Manager::_handle_client_message(ibv_wc& wc, std::vector<Client*>& poll_send
     } else {
 
       allocated->_send_buffer[0].lease_id = client.response()[0].lease_id;
-      allocated->_send_buffer[0].cores = cores;
-      allocated->_send_buffer[0].memory = memory;
+      allocated->_send_buffer[0].cores = client.response()[0].cores;
+      allocated->_send_buffer[0].memory = client.response()[0].memory;
 
       allocated->_connection->post_send(
         allocated->_send_buffer,


### PR DESCRIPTION
Reserve the value -1 for memory in LeaseRequest to lease an executor with the maximum amount of free memory available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of memory leasing requests by allowing the entire available memory to be leased when requested.
	- Enhanced validation to reject leasing requests with non-positive core or memory values.
- **Documentation**
	- Clarified comments regarding the interpretation of core values for client disconnection requests.
- **New Features**
	- Added reporting of allocated cores and memory in lease responses for more accurate resource tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->